### PR TITLE
Do NOT set SAI_OBJECT_NULL_ID as a value to SAI_PORT_ATTR_INGRESS_ACL

### DIFF
--- a/meta/sai_meta.cpp
+++ b/meta/sai_meta.cpp
@@ -6066,13 +6066,11 @@ sai_status_t meta_sai_set_oid(
         SAI_NULL_OBJECT_ID == value.oid)
     {
         // Do nothing.
-        SWSS_LOG_NOTICE("Ignoring PORT ACL attribute set");
+        SWSS_LOG_NOTICE("Ignoring %s attribute set with NULL object ID", md->attridname);
     }
     // Temporary code end.
     else
     {
-        SWSS_LOG_NOTICE("Setting attribute %d", attr->id);
-
         status = set(object_type, object_id, attr);
 
         if (status == SAI_STATUS_SUCCESS)


### PR DESCRIPTION
Temporarily avoiding setting SAI_NULL_OBJECT_ID as attribute value to SAI_PORT_ATTR_INGRESS_ACL attribute. Because Braodcom SAI ADK, returns error if the value of this attribute is NULL object ID. It expects the value to be some valid object ID. But when we want to delete the ACL group, as per SAI API documentation we should set this attribute SAI_OBJECT_NULL_ID. Hence raised a case CS9616135 in Broadcom portal to fix the same. Meanwhile, to continue testing, putting this workaround.