### PR TITLE
Return correct error code

### DIFF
--- a/meta/sai_meta.cpp
+++ b/meta/sai_meta.cpp
@@ -1824,14 +1824,6 @@ sai_status_t meta_port_remove_validation(
         return SAI_STATUS_SUCCESS;
     }
 
-    if (object_reference_count(port_id) != 0)
-    {
-        SWSS_LOG_ERROR("port %s reference count is not zero, can't remove",
-                sai_serialize_object_id(port_id).c_str());
-
-        return SAI_STATUS_OBJECT_IN_USE;
-    }
-
     if (!meta_is_object_in_default_state(port_id))
     {
         SWSS_LOG_ERROR("port %s is not in default state, can't remove",
@@ -1943,7 +1935,7 @@ sai_status_t meta_generic_validation_remove(
 
         SWSS_LOG_ERROR("object 0x%" PRIx64 " reference count is %d, can't remove", oid, count);
 
-        return SAI_STATUS_INVALID_PARAMETER;
+        return SAI_STATUS_OBJECT_IN_USE;
     }
 
     if (meta_key.objecttype == SAI_OBJECT_TYPE_PORT)


### PR DESCRIPTION
What I did:
Changed the error code from SAI_STATUS_INVALID_PARAMETER to SAI_STATUS_OBJECT_IN_USE in meta_generic_validation_remove(). Also, deleted the similar check in port object validation as that is NOT required.

Why I did:
When an object has 1 or more references, and it's been requested to delete the object, orchagent expects SAI_STATUS_OBJECT_IN_USE error code. For now, this is true for port object. I believe this should be the case for all objects as well.

How I tested it:
While testing dynamic port breakout, port object was being deleted and it was being referenced by router interface object. Orchagent was expecting SAI_STATUS_OBJECT_IN_USE but receiving SAI_STATUS_INVALID_PARAMETER, hence it was throwing an exception.. After the fix, correct error code is being returned and orchagent waits for the dependencies to be removed before deleting the port.