### PR TITLE
Remove FDB entries from meta DB as soon as syncd flush is called

### DIFF
--- a/meta/sai_meta.cpp
+++ b/meta/sai_meta.cpp
@@ -6747,7 +6747,66 @@ sai_status_t meta_sai_flush_fdb_entries(
     // there are no mandatory attributes
     // there are no conditional attributes
 
-    return flush_fdb_entries(switch_id, attr_count, attr_list);
+    auto status = flush_fdb_entries(switch_id, attr_count, attr_list);
+
+    if (status = SAI_STATUS_SUCCESS)
+    {
+        // use same logic as notification, so create notification event
+
+        std::vector<int32_t> types;
+
+        auto *et = sai_metadata_get_attr_by_id(SAI_FDB_FLUSH_ATTR_ENTRY_TYPE, attr_count, attr_list);
+
+        if (et)
+        {
+            switch (et->value.s32)
+            {
+                case SAI_FDB_FLUSH_ENTRY_TYPE_DYNAMIC:
+                    types.push_back(SAI_FDB_ENTRY_TYPE_DYNAMIC);
+                    break;
+
+                case SAI_FDB_FLUSH_ENTRY_TYPE_STATIC:
+                    types.push_back(SAI_FDB_ENTRY_TYPE_STATIC);
+                    break;
+
+                default:
+                    types.push_back(SAI_FDB_ENTRY_TYPE_DYNAMIC);
+                    types.push_back(SAI_FDB_ENTRY_TYPE_STATIC);
+                    break;
+            }
+        }
+        else
+        {
+            // no type specified so we need to flush static and dynamic entries
+
+            types.push_back(SAI_FDB_ENTRY_TYPE_DYNAMIC);
+            types.push_back(SAI_FDB_ENTRY_TYPE_STATIC);
+        }
+
+        for (auto type: types)
+        {
+            sai_fdb_event_notification_data_t data = {};
+
+            auto *bv_id = sai_metadata_get_attr_by_id(SAI_FDB_FLUSH_ATTR_BV_ID, attr_count, attr_list);
+            auto *bp_id = sai_metadata_get_attr_by_id(SAI_FDB_FLUSH_ATTR_BRIDGE_PORT_ID, attr_count, attr_list);
+
+            sai_attribute_t list[2];
+
+            list[0].id = SAI_FDB_ENTRY_ATTR_BRIDGE_PORT_ID;
+            list[0].value.oid = bp_id ? bp_id->value.oid : SAI_NULL_OBJECT_ID;
+
+            list[1].id = SAI_FDB_ENTRY_ATTR_TYPE;
+            list[1].value.s32 = type;
+
+            data.event_type = SAI_FDB_EVENT_FLUSHED;
+            data.fdb_entry.switch_id = switch_id;
+            data.fdb_entry.bv_id = (bv_id) ? bv_id->value.oid : SAI_NULL_OBJECT_ID;
+            data.attr_count = 2;
+            data.attr = list;
+
+            meta_sai_on_fdb_flush_event_consolidated(data);
+        }
+    }
 }
 
 // NAT


### PR DESCRIPTION
Took this code from PR 581 in azure/sonic-sairedis.

This helps to flush FDB entry from SAI meta DB and in turn helps to delete the bridge_port_OID

Behavior before the fix:
When a port is removed from VLAN, and we flush the FDB entries, lib sairedis would ask syncd to first remove the FDB entry and then after receiving the notification from syncd, it(lib sai redis)would remove the FDB entry from Meta DB. But by this time, if orchagent asks the library to remove the bridge port, which was referenced by the FDB entry, lib sairedis would return error with non zero reference count.

After fix:
When lib sairedis asks syncd to remove FDB entry, immediately it would delete the entry from meta DB also. 

Before the fix, DPB VLAN scale test case used to fail. Now it passes consistently

```
vapatil@server09:~/workspace/DPB/sonic-buildimage/src/sonic-swss/tests$ sudo pytest --pdb -s -v --dvsname=vs-vp test_port_dpb_vlan.py
[sudo] password for vapatil:
======================================================================= test session starts ========================================================================
platform linux2 -- Python 2.7.15+, pytest-3.3.0, py-1.8.0, pluggy-0.6.0 -- /usr/bin/python
cachedir: .cache
rootdir: /home/vapatil/workspace/DPB/sonic-buildimage/src/sonic-swss/tests, inifile:
collected 4 items

test_port_dpb_vlan.py::TestPortDPBVlan::test_dependency remove extra link dummy
PASSED                                                                                               [ 25%]
test_port_dpb_vlan.py::TestPortDPBVlan::test_one_port_one_vlan PASSED                                                                                        [ 50%]
test_port_dpb_vlan.py::TestPortDPBVlan::test_one_port_multiple_vlan PASSED                                                                                   [ 75%]
test_port_dpb_vlan.py::TestPortDPBVlan::test_all_port_10_vlans PASSED                                                                                        [100%]

=================================================================== 4 passed in 1019.62 seconds ====================================================================
vapatil@server09:~/workspace/DPB/sonic-buildimage/src/sonic-swss/tests$
```